### PR TITLE
fix isValidPrinter to avoid crashes

### DIFF
--- a/src/utils/windows-printer-valid.ts
+++ b/src/utils/windows-printer-valid.ts
@@ -21,12 +21,12 @@ export default function isValidPrinter(printer: string): {
     let [label, value] = line.split(":").map((el) => el.trim());
 
     // handle array dots
-    if (value.match(/^{(.*)(\.{3})}$/)) {
+    if (value?.match(/^{(.*)(\.{3})}$/)) {
       value = value.replace("...}", "}");
     }
 
     // handle array returns
-    const matches = value.match(/^{(.*)}$/);
+    const matches = value?.match(/^{(.*)}$/);
 
     if (matches && matches[1]) {
       // @ts-ignore


### PR DESCRIPTION
If you don't mind accepting this PR, it fixes a bug that I've seen on some computers where some printers don't respect the regexes, and hence the `.match` throws an error of the type of the type "property 'match' doesn't exist on undefined..."